### PR TITLE
remove extraneous import from test

### DIFF
--- a/t/01-word.t
+++ b/t/01-word.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Crypt::RandPasswd qw(word);
+use Crypt::RandPasswd;
 use Test::More 0.88 tests => 20;
 
 my $word;


### PR DESCRIPTION
Crypt::RandPassword does not export anything, but a test was trying to import a function but not use it. This unhandled import will cause errors in future versions of perl.